### PR TITLE
disable time out for solr download

### DIFF
--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -53,6 +53,7 @@ class must-have {
     path => "/usr/bin/:/bin/",
     require => Exec["accept_license"],
     logoutput => true,
+    timeout => 0,
   }
 
   file { "/etc/init/solr.conf":


### PR DESCRIPTION
I was not able to create a workable solr vagrant machine, because the curl command failed due to timeout. Disabling the timeout for this "download_solr" exec command fixed the issue.
